### PR TITLE
Gamma-correct rendering (and some other stuff)

### DIFF
--- a/projects/engine/assets/shaders/BackBufferFinalize.hlsl
+++ b/projects/engine/assets/shaders/BackBufferFinalize.hlsl
@@ -1,6 +1,14 @@
 #include "Common.hlsl"
 
+//=>:(Usage, VS, vs_5_0)
+//=>:(Usage, PS, ps_5_0)
+
 // Input structs for vertex and pixel shader
+struct VS_INPUT
+{
+	float3 mPos : POSITION;
+};
+
 struct PS_INPUT
 {
 	float4 mPos : SV_POSITION;
@@ -10,13 +18,10 @@ struct PS_INPUT
 //--------------------------------------------------------------------------------------
 // Vertex Shader
 //--------------------------------------------------------------------------------------
-PS_INPUT VS(uint id : SV_VertexID)
+PS_INPUT VS(VS_INPUT input)
 {
 	PS_INPUT output;
-
-	float2 texCoord = float2(id & 1, id >> 1);
-	output.mPos = float4((texCoord.x - 0.5f) * 2.0f, -(texCoord.y - 0.5f) * 2.0f, 0.0f, 1.0f);
-
+	output.mPos = float4(input.mPos, 1.0);
 	return output;
 }
 

--- a/projects/engine/assets/shaders/BackBufferFinalize.hlsl
+++ b/projects/engine/assets/shaders/BackBufferFinalize.hlsl
@@ -1,0 +1,33 @@
+#include "Common.hlsl"
+
+// Input structs for vertex and pixel shader
+struct PS_INPUT
+{
+	float4 mPos : SV_POSITION;
+};
+
+
+//--------------------------------------------------------------------------------------
+// Vertex Shader
+//--------------------------------------------------------------------------------------
+PS_INPUT VS(uint id : SV_VertexID)
+{
+	PS_INPUT output;
+
+	float2 texCoord = float2(id & 1, id >> 1);
+	output.mPos = float4((texCoord.x - 0.5f) * 2.0f, -(texCoord.y - 0.5f) * 2.0f, 0.0f, 1.0f);
+
+	return output;
+}
+
+
+//--------------------------------------------------------------------------------------
+// Pixel Shader
+//--------------------------------------------------------------------------------------
+float4 PS(PS_INPUT input) : SV_Target
+{
+	int3 texCoord = int3(input.mPos.xy, 0);
+
+	// TODO This is where we would do HDR, tonemapping, etc.
+	return float4(saturate(g_lightingBuffer.Load(texCoord).xyz), 1.0f);
+}

--- a/projects/engine/assets/shaders/Common.hlsl
+++ b/projects/engine/assets/shaders/Common.hlsl
@@ -71,7 +71,8 @@ Texture2D g_diffuseMap	: register(t0);
 Texture2D g_specularMap	: register(t1);
 Texture2D g_emissiveMap	: register(t2);
 
-Texture2D g_diffuseBuffer	: register(t3);
-Texture2D g_normalBuffer	: register(t4);
-Texture2D g_specularBuffer	: register(t5);
-Texture2D g_depthBuffer		: register(t6);
+Texture2D g_lightingBuffer	: register(t3);
+Texture2D g_diffuseBuffer	: register(t4);
+Texture2D g_normalBuffer	: register(t5);
+Texture2D g_specularBuffer	: register(t6);
+Texture2D g_depthBuffer		: register(t7);

--- a/projects/engine/assets/shaders/CopyTexture.hlsl
+++ b/projects/engine/assets/shaders/CopyTexture.hlsl
@@ -4,6 +4,11 @@
 //=>:(Usage, PS, ps_5_0)
 
 // Input structs for vertex and pixel shader
+struct VS_INPUT
+{
+	float3 mPos : POSITION;
+};
+
 struct PS_INPUT
 {
 	float4 mPos : SV_POSITION;
@@ -13,13 +18,10 @@ struct PS_INPUT
 //--------------------------------------------------------------------------------------
 // Vertex Shader
 //--------------------------------------------------------------------------------------
-PS_INPUT VS(uint id : SV_VertexID)
+PS_INPUT VS(VS_INPUT input)
 {
 	PS_INPUT output;
-
-	float2 texCoord = float2(id & 1, id >> 1);
-	output.mPos = float4((texCoord.x - 0.5f) * 2.0f, -(texCoord.y - 0.5f) * 2.0f, 0.0f, 1.0f);
-
+	output.mPos = float4(input.mPos, 1.0);
 	return output;
 }
 

--- a/projects/engine/assets/shaders/DeferredLighting.hlsl
+++ b/projects/engine/assets/shaders/DeferredLighting.hlsl
@@ -92,7 +92,7 @@ float4 PS(PS_INPUT input) : SV_Target
 	float3 N = DecodeNormal(sampleNormal);
 	float3 L = normalize(-g_directionalLight.m_lightDirection.xyz); // We transform this to VS on the CPU
 	float3 V = normalize(-positionVS);
-	float3 R = normalize(reflect(-L, N));
+	float3 H = normalize(L + V);
 	float  lightIntensity = g_directionalLight.m_lightIntensity;
 	float3 lightColor = g_directionalLight.m_lightColor;
 
@@ -107,10 +107,10 @@ float4 PS(PS_INPUT input) : SV_Target
 		float3 diffuse = materialDiffuseColor * lightColor * NdotL;
 
 		// Calculate specular term
-		float RdotV = max(0.0, dot(R, V));
-		float3 specular = materialSpecularColor * lightColor * pow(RdotV, materialSpecularPower);
+		float NdotH = max(0.0, dot(N, H)); // Blinn-Phong
+		float3 specular = materialSpecularColor * lightColor * pow(NdotH, materialSpecularPower);
 
-		phong = saturate(lightIntensity * (diffuse + specular));
+		phong = lightIntensity * (diffuse + specular);
 	}
 
 	return float4(phong, 1.0f);

--- a/projects/engine/assets/shaders/DeferredLighting.hlsl
+++ b/projects/engine/assets/shaders/DeferredLighting.hlsl
@@ -4,10 +4,14 @@
 //=>:(Usage, PS, ps_5_0)
 
 // Input structs for vertex and pixel shader
+struct VS_INPUT
+{
+	float3 mPos : POSITION;
+};
+
 struct PS_INPUT
 {
 	float4 mPos : SV_POSITION;
-	float2 mTexCoord : TEXCOORD0;
 };
 
 // Convert clip space coordinates to view space
@@ -60,12 +64,10 @@ float DecodeSpecPower(float inEncodedSpecularPower)
 //--------------------------------------------------------------------------------------
 // Vertex Shader
 //--------------------------------------------------------------------------------------
-PS_INPUT VS(uint id : SV_VertexID)
+PS_INPUT VS(VS_INPUT input)
 {
 	PS_INPUT output;
-
-	output.mTexCoord = float2(id & 1, id >> 1);
-	output.mPos = float4((output.mTexCoord.x - 0.5f) * 2.0f, -(output.mTexCoord.y - 0.5f) * 2.0f, 0.0f, 1.0f);
+	output.mPos = float4(input.mPos, 1.0);
 	return output;
 }
 

--- a/projects/engine/src/include/Rendering/RenderingCommon.h
+++ b/projects/engine/src/include/Rendering/RenderingCommon.h
@@ -33,6 +33,7 @@ namespace MAD
 		EmissiveMap,
 
 		// ------------- Defined by renderer -------------------
+		LightingBuffer,
 		DiffuseBuffer,
 		NormalBuffer,
 		SpecularBuffer,
@@ -44,7 +45,7 @@ namespace MAD
 
 	enum class ERenderTargetSlot
 	{
-		BackBuffer = 0,
+		LightingBuffer = 0,
 		DiffuseBuffer,
 		NormalBuffer,
 		SpecularBuffer,

--- a/projects/engine/src/private/Core/Character.cpp
+++ b/projects/engine/src/private/Core/Character.cpp
@@ -24,10 +24,10 @@ namespace MAD
 
 		auto meshComps = GetComponentsByType<CMeshComponent>();
 		auto rot = Matrix::Identity;// Matrix::CreateRotationY(ConvertToRadians(45.0f));
-		//meshComps[0].lock()->TEMPInitializeMeshInstance("engine\\meshes\\nanosuit\\nanosuit.obj", Matrix::CreateRotationY(ConvertToRadians(180.0f)) * Matrix::CreateTranslation(Vector3(0, 0, -5.0f)));
-		meshComps[0].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\sphere.obj", Matrix::CreateTranslation(Vector3(0, 0, -5.0f)));
-		meshComps[1].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\cube.obj", rot * Matrix::CreateTranslation(Vector3(3.0f, 0, -5.0f)));
-		meshComps[2].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\cube.obj", rot * Matrix::CreateTranslation(Vector3(-3.0f, 0, -5.0f)));
+		meshComps[0].lock()->TEMPInitializeMeshInstance("engine\\meshes\\nanosuit\\nanosuit.obj", Matrix::CreateRotationY(ConvertToRadians(180.0f)) * Matrix::CreateTranslation(Vector3(0, -12.0, -6.0f)));
+		//meshComps[0].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\sphere.obj", Matrix::CreateTranslation(Vector3(0, 0, -5.0f)));
+		//meshComps[1].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\cube.obj", rot * Matrix::CreateTranslation(Vector3(3.0f, 0, -5.0f)));
+		//meshComps[2].lock()->TEMPInitializeMeshInstance("engine\\meshes\\primitives\\cube.obj", rot * Matrix::CreateTranslation(Vector3(-3.0f, 0, -5.0f)));
 
 		Vector3 dir = Vector3(0.0f, -0.86602540378f, -0.5f);
 		dir.Normalize();

--- a/projects/engine/src/private/Core/GameEngine.cpp
+++ b/projects/engine/src/private/Core/GameEngine.cpp
@@ -151,7 +151,7 @@ namespace MAD
 	{
 		eastl::weak_ptr<OGameWorld> initialGameWorld = SpawnGameWorld<OGameWorld>("Gameplay_World");
 
-		mRenderer->SetWorldAmbientColor(Color(0.1f, 0.1f, 0.1f, 1.0f));
+		mRenderer->SetWorldAmbientColor(Color(0.2f, 0.2f, 0.2f, 1.0f));
 		mRenderer->SetBackBufferClearColor(Color(0.1f, 0.1f, 0.1f, 1.0f));
 
 		SControlScheme& renderScheme = SControlScheme("RenderDebug")

--- a/projects/engine/src/private/Core/GameEngine.cpp
+++ b/projects/engine/src/private/Core/GameEngine.cpp
@@ -152,7 +152,7 @@ namespace MAD
 		eastl::weak_ptr<OGameWorld> initialGameWorld = SpawnGameWorld<OGameWorld>("Gameplay_World");
 
 		mRenderer->SetWorldAmbientColor(Color(0.2f, 0.2f, 0.2f, 1.0f));
-		mRenderer->SetBackBufferClearColor(Color(0.1f, 0.1f, 0.1f, 1.0f));
+		mRenderer->SetBackBufferClearColor(Color(0.2f, 0.2f, 0.2f, 1.0f));
 
 		SControlScheme& renderScheme = SControlScheme("RenderDebug")
 			.RegisterEvent("NormalView", '0')

--- a/projects/engine/src/private/Rendering/GraphicsDriver.cpp
+++ b/projects/engine/src/private/Rendering/GraphicsDriver.cpp
@@ -71,7 +71,6 @@ namespace MAD
 
 		// Constant configuration
 		const UINT g_swapChainBufferCount = 3;
-		const DXGI_FORMAT g_swapChainFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
 
 		// Graphics driver object stores
 #define DECLARE_OBJECT_STORE(IdType, D3DType, storeName) eastl::hash_map<IdType, ComPtr<D3DType>> storeName;
@@ -141,7 +140,7 @@ namespace MAD
 			MEM_ZERO(scd);
 			scd.Width = 0;
 			scd.Height = 0;
-			scd.Format = g_swapChainFormat;
+			scd.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 			scd.Stereo = FALSE;
 			scd.SampleDesc.Count = 1;
 			scd.SampleDesc.Quality = 0;
@@ -190,7 +189,13 @@ namespace MAD
 
 		ComPtr<ID3D11RenderTargetView>& backBufferRTV = g_renderTargetStore[m_backBuffer];
 
-		hr = g_d3dDevice->CreateRenderTargetView(backBuffer.Get(), nullptr, backBufferRTV.GetAddressOf());
+		D3D11_RENDER_TARGET_VIEW_DESC renderTargetDesc;
+		MEM_ZERO(renderTargetDesc);
+		renderTargetDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+		renderTargetDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+		renderTargetDesc.Texture2D.MipSlice = 0;
+
+		hr = g_d3dDevice->CreateRenderTargetView(backBuffer.Get(), &renderTargetDesc, backBufferRTV.GetAddressOf());
 		HR_ASSERT_SUCCESS(hr, "Failed to create render target view from back buffer");
 	}
 
@@ -313,7 +318,33 @@ namespace MAD
 		}
 		else if (extension == ".png" || extension == ".bmp" || extension == ".jpeg" || extension == ".jpg" || extension == ".tiff")
 		{
-			hr = DirectX::CreateWICTextureFromFile(g_d3dDevice.Get(), widePath.c_str(), texture.GetAddressOf(), srv.GetAddressOf());
+			//hr = DirectX::CreateWICTextureFromFile(g_d3dDevice.Get(), widePath.c_str(), texture.GetAddressOf(), srv.GetAddressOf());
+			hr = DirectX::CreateWICTextureFromFileEx(g_d3dDevice.Get(), widePath.c_str(), 0, D3D11_USAGE_IMMUTABLE, D3D11_BIND_SHADER_RESOURCE, 0, 0, true, texture.GetAddressOf(), srv.GetAddressOf());
+
+			/*	HRESULT __cdecl CreateWICTextureFromFileEx(
+					_In_ ID3D11Device* d3dDevice,
+					_In_z_ const wchar_t* szFileName,
+					_In_ size_t maxsize,
+					_In_ D3D11_USAGE usage,
+					_In_ unsigned int bindFlags,
+					_In_ unsigned int cpuAccessFlags,
+					_In_ unsigned int miscFlags,
+					_In_ bool forceSRGB,
+					_Outptr_opt_ ID3D11Resource** texture,
+					_Outptr_opt_ ID3D11ShaderResourceView** textureView);*/
+
+			/*	HRESULT __cdecl CreateWICTextureFromFileEx(
+					_In_ ID3D11Device* d3dDevice,
+					_In_opt_ ID3D11DeviceContext* d3dContext,
+					_In_z_ const wchar_t* szFileName,
+					_In_ size_t maxsize,
+					_In_ D3D11_USAGE usage,
+					_In_ unsigned int bindFlags,
+					_In_ unsigned int cpuAccessFlags,
+					_In_ unsigned int miscFlags,
+					_In_ bool forceSRGB,
+					_Outptr_opt_ ID3D11Resource** texture,
+					_Outptr_opt_ ID3D11ShaderResourceView** textureView);*/
 		}
 		else
 		{

--- a/projects/engine/src/private/Rendering/GraphicsDriver.cpp
+++ b/projects/engine/src/private/Rendering/GraphicsDriver.cpp
@@ -314,37 +314,15 @@ namespace MAD
 		HRESULT hr;
 		if (extension == ".dds")
 		{
-			hr = DirectX::CreateDDSTextureFromFile(g_d3dDevice.Get(), widePath.c_str(), texture.GetAddressOf(), srv.GetAddressOf());
+			//hr = DirectX::CreateDDSTextureFromFile(g_d3dDevice.Get(), widePath.c_str(), texture.GetAddressOf(), srv.GetAddressOf());
+			// TODO: Need some way to only load sRGB if specified
+			hr = DirectX::CreateDDSTextureFromFileEx(g_d3dDevice.Get(), widePath.c_str(), 0, D3D11_USAGE_IMMUTABLE, D3D11_BIND_SHADER_RESOURCE, 0, 0, true, texture.GetAddressOf(), srv.GetAddressOf());
 		}
 		else if (extension == ".png" || extension == ".bmp" || extension == ".jpeg" || extension == ".jpg" || extension == ".tiff")
 		{
 			//hr = DirectX::CreateWICTextureFromFile(g_d3dDevice.Get(), widePath.c_str(), texture.GetAddressOf(), srv.GetAddressOf());
+			// TODO: Need some way to only load sRGB if specified
 			hr = DirectX::CreateWICTextureFromFileEx(g_d3dDevice.Get(), widePath.c_str(), 0, D3D11_USAGE_IMMUTABLE, D3D11_BIND_SHADER_RESOURCE, 0, 0, true, texture.GetAddressOf(), srv.GetAddressOf());
-
-			/*	HRESULT __cdecl CreateWICTextureFromFileEx(
-					_In_ ID3D11Device* d3dDevice,
-					_In_z_ const wchar_t* szFileName,
-					_In_ size_t maxsize,
-					_In_ D3D11_USAGE usage,
-					_In_ unsigned int bindFlags,
-					_In_ unsigned int cpuAccessFlags,
-					_In_ unsigned int miscFlags,
-					_In_ bool forceSRGB,
-					_Outptr_opt_ ID3D11Resource** texture,
-					_Outptr_opt_ ID3D11ShaderResourceView** textureView);*/
-
-			/*	HRESULT __cdecl CreateWICTextureFromFileEx(
-					_In_ ID3D11Device* d3dDevice,
-					_In_opt_ ID3D11DeviceContext* d3dContext,
-					_In_z_ const wchar_t* szFileName,
-					_In_ size_t maxsize,
-					_In_ D3D11_USAGE usage,
-					_In_ unsigned int bindFlags,
-					_In_ unsigned int cpuAccessFlags,
-					_In_ unsigned int miscFlags,
-					_In_ bool forceSRGB,
-					_Outptr_opt_ ID3D11Resource** texture,
-					_Outptr_opt_ ID3D11ShaderResourceView** textureView);*/
 		}
 		else
 		{

--- a/projects/engine/src/private/Rendering/Mesh.cpp
+++ b/projects/engine/src/private/Rendering/Mesh.cpp
@@ -128,8 +128,6 @@ namespace MAD
 												 aiProcessPreset_TargetRealtime_MaxQuality);
 
 		auto path = inFilePath.substr(0, inFilePath.find_last_of('\\') + 1);
-		auto ext  = inFilePath.substr(inFilePath.find_last_of('.') + 1);
-		ext.make_lower();
 
 		if (!scene || scene->mFlags == AI_SCENE_FLAGS_INCOMPLETE)
 		{
@@ -184,12 +182,6 @@ namespace MAD
 
 				float specular_power = 0.0f;
 				aiMaterial->Get(AI_MATKEY_SHININESS, specular_power);
-				if (ext == "obj")
-				{
-					// Assimp arbitrarily multiplies the specular power in .obj files by 4.0...
-					specular_power /= 4.0f;
-				}
-
 				LOG_IMPORT(Log, "\tSpecular power = %f\n", specular_power);
 				madMaterial.m_mat.m_specularPower = specular_power;
 

--- a/projects/engine/src/private/Rendering/Renderer.cpp
+++ b/projects/engine/src/private/Rendering/Renderer.cpp
@@ -219,10 +219,12 @@ namespace MAD
 	{
 		static const float zero[] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-		//g_graphicsDriver.ClearBackBuffer(zero);
 		g_graphicsDriver.ClearDepthStencil(m_gBufferPassDescriptor.m_depthStencilView, true, 1.0f);
 
+		// Clear the light accumulation buffer to the screen clear color
 		g_graphicsDriver.ClearRenderTarget(m_gBufferPassDescriptor.m_renderTargets[0], m_clearColor);
+
+		// Clear other G-buffers to 0
 		for (unsigned i = 1; i < m_gBufferPassDescriptor.m_renderTargets.size(); ++i)
 		{
 			auto renderTarget = m_gBufferPassDescriptor.m_renderTargets[i];
@@ -285,7 +287,7 @@ namespace MAD
 		}
 
 		// Copy the finalized linear lighting buffer to the back buffer
-		// This (will) perform HDR and already performs gamma correction
+		// This (will) perform HDR lighting corrections and already performs gamma correction
 		g_graphicsDriver.SetRenderTargets(&m_backBuffer, 1, nullptr);
 		g_graphicsDriver.SetPixelShaderResource(m_gBufferShaderResources[AsIntegral(ETextureSlot::LightingBuffer) - AsIntegral(ETextureSlot::LightingBuffer)], ETextureSlot::LightingBuffer);
 		g_graphicsDriver.SetBlendState(SBlendStateId::Invalid);
@@ -379,7 +381,7 @@ namespace MAD
 
 	void URenderer::SetWorldAmbientColor(Color inColor)
 	{
-		// Convet from sRGB space to linear color space.
+		// Convert from sRGB space to linear color space.
 		// This is then converted back to sRGB space when rendering to the back buffer
 		// and then back to linear by the monitor...
 		m_perSceneConstants.m_ambientColor.x = powf(inColor.x, 2.2f);


### PR DESCRIPTION
- Adds gamma-correct rendering
  - Load textures as sRGB-aware (the underlying texture format is changed to sRGB so that samples are auto-converted to linear color space)
  - Back buffer is an sRGB type so that writes are auto-converted to sRGB space
  - All lighting is done in linear space
- Change Phong specular to Blinn-Phong
- Removes old way of rendering fullscreen quad using SV_VertexID and actually just draws a quad to allow graphics debugging
